### PR TITLE
Czech ISO-639-1 fixed according Wikipedia

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -2,7 +2,7 @@
 "ar": "arabic",
 "bg": "bulgarian",
 "ca": "catalan",
-"cz": "czech",
+"cs": "czech",
 "da": "danish",
 "nl": "dutch",
 "en": "english",


### PR DESCRIPTION
According Wikipedia:
https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

The iso code for Czech is "cs" not "cz".